### PR TITLE
fix modernize

### DIFF
--- a/internal/api/events.go
+++ b/internal/api/events.go
@@ -161,7 +161,7 @@ func (a *API) handlePostNewEventCommon(w http.ResponseWriter, r *http.Request, p
 // Example: "target=foobar, priority=42" -> {"target": "foobar", "priority": "42"}
 func parseRoutingInfo(input string) (map[string]string, error) {
 	result := make(map[string]string)
-	for _, field := range strings.Split(input, ",") {
+	for field := range strings.SplitSeq(input, ",") {
 		field = strings.TrimSpace(field)
 		if field == "" {
 			continue

--- a/internal/handlers/active-directory-deployment.go
+++ b/internal/handlers/active-directory-deployment.go
@@ -48,7 +48,7 @@ type activeDirectoryDeploymentV1Event struct {
 		Outcome   string                   `json:"outcome"`
 		StartedAt activeDirectoryEventTime `json:"started_at"`
 		// FinishedAt and DurationSeconds are not set for outcome "failed".
-		FinishedAt      activeDirectoryEventTime `json:"finished_at,omitempty"`
+		FinishedAt      activeDirectoryEventTime `json:"finished_at"`
 		DurationSeconds any                      `json:"duration,omitempty"`
 	} `json:"ad_deployment"`
 	GitRepos map[string]struct {


### PR DESCRIPTION
events.go: Range over SplitSeq
active-directory-deployment.go: remove obsolete Omitempty