### PR TITLE
Read cluster regex from environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,7 @@ To configure these delivery paths, the following environment variables are inspe
 | Variable | Default | Explanation |
 | -------- | ------- | ----------- |
 | `TENSO_AWX_WORKFLOW_SWIFT_CONTAINER` | *(required)* | The name of the target Swift container for `infra-workflow-to-swift.v1` delivery. |
+| `TENSO_HELM_DEPLOYMENT_CLUSTER_REGEX` | *(required)* | A regex compiled as `regexpext.BoundedRegexp` which extracts the cluster name from the `cluster` field in the incoming `helm-deployment-from-concourse.v1` payload. The cluster name is used for routing and in the ServiceNow change template. |
 | `TENSO_HELM_DEPLOYMENT_LOGSTASH_HOST` | *(required)* | The host:port pair of the Logstash service for `helm-deployment-to-elk.v1` delivery. |
 | `TENSO_HELM_DEPLOYMENT_SWIFT_CONTAINER` | *(required)* | The name of the target Swift container for `helm-deployment-to-swift.v1` delivery. |
 | `TENSO_TERRAFORM_DEPLOYMENT_SWIFT_CONTAINER` | *(required)* | The name of the target Swift container for `terraform-deployment-to-swift.v1` delivery. |

--- a/internal/handlers/helm-deployment.go
+++ b/internal/handlers/helm-deployment.go
@@ -10,6 +10,7 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"regexp"
 	"strings"
 	"time"
 
@@ -17,6 +18,7 @@ import (
 	"github.com/majewsky/schwift/v2"
 	"github.com/sapcc/go-api-declarations/deployevent"
 	"github.com/sapcc/go-bits/osext"
+	"github.com/sapcc/go-bits/regexpext"
 
 	"github.com/sapcc/tenso/internal/servicenow"
 	"github.com/sapcc/tenso/internal/tenso"
@@ -42,10 +44,20 @@ func releaseDescriptorsOf(event deployevent.Event, sep string) (result []string)
 // ValidationHandler
 
 type helmDeploymentValidator struct {
+	clusterRx *regexp.Regexp
 }
 
 // Init implements the tenso.ValidationHandler interface.
 func (h *helmDeploymentValidator) Init(context.Context, *gophercloud.ProviderClient, gophercloud.EndpointOpts) error {
+	clusterRegexEnvVar := "TENSO_HELM_DEPLOYMENT_CLUSTER_REGEX"
+	clusterString, err := osext.NeedGetenv(clusterRegexEnvVar)
+	if err != nil {
+		return err
+	}
+	h.clusterRx, err = regexpext.BoundedRegexp(clusterString).Regexp()
+	if err != nil {
+		return fmt.Errorf("while compiling %s: %w", clusterRegexEnvVar, err)
+	}
 	return nil
 }
 
@@ -74,7 +86,7 @@ func (h *helmDeploymentValidator) ValidatePayload(payload []byte) (*tenso.Payloa
 		if relInfo == nil {
 			return nil, fmt.Errorf(`helm-release[%d] may not be nil`, idx)
 		}
-		//TODO: Can we do regex matches to validate the contents of Name, Namespace, ChartID, ChartPath?
+		// TODO: Can we do regex matches to validate the contents of Name, Namespace, ChartID, ChartPath?
 		if relInfo.Name == "" {
 			return nil, fmt.Errorf(`invalid value for field helm-release[].name: %q`, relInfo.Name)
 		}
@@ -87,7 +99,7 @@ func (h *helmDeploymentValidator) ValidatePayload(payload []byte) (*tenso.Payloa
 		if relInfo.ChartID != "" && relInfo.ChartPath != "" {
 			return nil, fmt.Errorf(`in helm-release %q: chart-id and chart-path can not both be set`, relInfo.Name)
 		}
-		if !clusterRx.MatchString(relInfo.Cluster) {
+		if !h.clusterRx.MatchString(relInfo.Cluster) {
 			return nil, fmt.Errorf(`in helm-release %q: invalid value for field cluster: %q`, relInfo.Name, relInfo.Cluster)
 		}
 		if !isClusterLocatedInRegion(relInfo.Cluster, event.Region) {
@@ -239,7 +251,7 @@ func (h *helmDeploymentToSNowTranslator) TranslatePayload(payload []byte, routin
 		Outcome:     event.CombinedOutcome(),
 		Summary:     "Deploy " + releaseDesc,
 		Description: fmt.Sprintf("Deployed %s with versions: %s\nDeployment log: %s\n\nOutcome: %s", releaseDesc, inputDesc, event.Pipeline.BuildURL, string(event.CombinedOutcome())),
-		Executee:    event.Pipeline.CreatedBy, //NOTE: can be empty
+		Executee:    event.Pipeline.CreatedBy, // NOTE: can be empty
 		Region:      event.Region,
 	}
 

--- a/internal/handlers/helm-deployment_test.go
+++ b/internal/handlers/helm-deployment_test.go
@@ -18,6 +18,7 @@ import (
 func TestHelmDeploymentValidationSuccess(t *testing.T) {
 	// we will not be using this, but we need some config for the DeliveryHandler for the test.Setup() to go through
 	t.Setenv("TENSO_HELM_DEPLOYMENT_LOGSTASH_HOST", "localhost:1")
+	t.Setenv("TENSO_HELM_DEPLOYMENT_CLUSTER_REGEX", "[a-z]{2}-[a-z]{2}-[0-9]{1}")
 
 	s := test.NewSetup(t,
 		test.WithRoute("helm-deployment-from-concourse.v1 -> helm-deployment-to-elk.v1"),
@@ -49,6 +50,7 @@ func TestHelmDeploymentValidationSuccess(t *testing.T) {
 
 func TestHelmDeploymentConversionToSNow(t *testing.T) {
 	t.Setenv("TENSO_SERVICENOW_MAPPING_CONFIG_PATH", "fixtures/servicenow-mapping-config.json")
+	t.Setenv("TENSO_HELM_DEPLOYMENT_CLUSTER_REGEX", "[a-z]{2}-[a-z]{2}-[0-9]{1}")
 
 	s := test.NewSetup(t,
 		test.WithRoute("helm-deployment-from-concourse.v1 -> helm-deployment-to-servicenow.v1"),

--- a/internal/handlers/utils.go
+++ b/internal/handlers/utils.go
@@ -30,9 +30,7 @@ func jsonUnmarshalStrict[T any](payload []byte) (T, error) {
 // terraform-deployment)
 
 var (
-	regionRx = regexp.MustCompile(`^[a-z]{2}-[a-z]{2}-[0-9]$`) // e.g. "qa-de-1"
-	// e.g. "qa-de-1" or "s-qa-de-1" or "ci-eu-de-2" or "st3-qa-de-1" or "a-qa-de-100" or "gh-actions-eu-de-2" or "cc274-qa-de-1" or "cc-b0-qa-de-1" or "rt-qa-de-1" or "prt-q-eu-de-1" or "mgmt-qa-de-1" or "k-master"
-	clusterRx     = regexp.MustCompile(`^(?:(?:|[a-z]-|ci[0-9]?-|st[0-9]?-|gh-actions-|cc[0-9]{3}-|cc-[a-z][0-9]-|rt-|prt-q-|prt-c-|prt-p-|mgmt-|lh-[a-z]-)?[a-z]{2}-[a-z]{2}-[0-9]{1,3}|k-master)$`)
+	regionRx      = regexp.MustCompile(`^[a-z]{2}-[a-z]{2}-[0-9]$`)       // e.g. "qa-de-1"
 	gitCommitRx   = regexp.MustCompile(`^[0-9a-f]{40}$`)                  // SHA-1 digest with lower-case digits
 	buildNumberRx = regexp.MustCompile(`^[1-9][0-9]*(?:\.[1-9][0-9]*)?$`) // e.g. "23" or "42.1"
 	sapUserIDRx   = regexp.MustCompile(`^(?:C[0-9]{7}|[DI][0-9]{6})$`)    // e.g. "D123456" or "C1234567"


### PR DESCRIPTION
The cluster regex is quite specific to the use of Tenso, so we want to remove it from the code.
In order to be able to cycle these configurations automatically, we are reading from a new environment variable instead of from the `servicenow-mapping`.
It would also be possible to make a separate json from this in future, if we want to move more things out.

helm-chart companion PR: https://github.com/sapcc/helm-charts/pull/11304