### PR TITLE
make region and az dynamic, allow ora-1 as AZ and ora as region

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,8 +178,10 @@ To configure these delivery paths, the following environment variables are inspe
 
 | Variable | Default | Explanation |
 | -------- | ------- | ----------- |
+| `TENSO_REGION_REGEX` | *(required)* | A regex compiled as `regexpext.BoundedRegexp` which extracts the region from the `region` field in the incoming payload. The region is used to find the data centers for the ServiceNow change template. |
 | `TENSO_AWX_WORKFLOW_SWIFT_CONTAINER` | *(required)* | The name of the target Swift container for `infra-workflow-to-swift.v1` delivery. |
-| `TENSO_HELM_DEPLOYMENT_CLUSTER_REGEX` | *(required)* | A regex compiled as `regexpext.BoundedRegexp` which extracts the cluster name from the `cluster` field in the incoming `helm-deployment-from-concourse.v1` payload. The cluster name is used for routing and in the ServiceNow change template. |
+| `TENSO_AWX_WORKFLOW_AZ_REGEX` | *(required)* | A regex compiled as `regexpext.BoundedRegexp` which extracts the availability zone from the `az` field in the incoming `infra-workflow-from-awx.v1` payload. The availability zone is used to find the data centers for the ServiceNow change template. |
+| `TENSO_HELM_DEPLOYMENT_CLUSTER_REGEX` | *(required)* | A regex compiled as `regexpext.BoundedRegexp` which extracts the cluster name from the `cluster` field in the incoming `helm-deployment-from-concourse.v1` payload. The cluster name is used in the description for the ServiceNow change template. |
 | `TENSO_HELM_DEPLOYMENT_LOGSTASH_HOST` | *(required)* | The host:port pair of the Logstash service for `helm-deployment-to-elk.v1` delivery. |
 | `TENSO_HELM_DEPLOYMENT_SWIFT_CONTAINER` | *(required)* | The name of the target Swift container for `helm-deployment-to-swift.v1` delivery. |
 | `TENSO_TERRAFORM_DEPLOYMENT_SWIFT_CONTAINER` | *(required)* | The name of the target Swift container for `terraform-deployment-to-swift.v1` delivery. |

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -4,11 +4,15 @@
 package api
 
 import (
+	"fmt"
+	"regexp"
 	"time"
 
 	"github.com/go-gorp/gorp/v3"
 	"github.com/gorilla/mux"
 	"github.com/sapcc/go-bits/gopherpolicy"
+	"github.com/sapcc/go-bits/osext"
+	"github.com/sapcc/go-bits/regexpext"
 
 	"github.com/sapcc/tenso/internal/tenso"
 )
@@ -18,12 +22,22 @@ type API struct {
 	Config    tenso.Configuration
 	DB        *gorp.DbMap
 	Validator gopherpolicy.Validator
+	RegionRx  *regexp.Regexp
 	timeNow   func() time.Time
 }
 
 // NewAPI creates an tenso API.
-func NewAPI(cfg tenso.Configuration, db *gorp.DbMap, validator gopherpolicy.Validator) *API {
-	return &API{cfg, db, validator, time.Now}
+func NewAPI(cfg tenso.Configuration, db *gorp.DbMap, validator gopherpolicy.Validator) (*API, error) {
+	regionRxEnvVar := "TENSO_REGION_REGEX"
+	regionRxString, err := osext.NeedGetenv(regionRxEnvVar)
+	if err != nil {
+		return nil, err
+	}
+	regionRx, err := regexpext.BoundedRegexp(regionRxString).Regexp()
+	if err != nil {
+		return nil, fmt.Errorf("while compiling %s: %w", regionRxEnvVar, err)
+	}
+	return &API{cfg, db, validator, regionRx, time.Now}, nil
 }
 
 // OverrideTimeNow is used by unit tests to inject a mock clock.

--- a/internal/api/events.go
+++ b/internal/api/events.go
@@ -89,7 +89,7 @@ func (a *API) handlePostNewEventCommon(w http.ResponseWriter, r *http.Request, p
 	if respondwith.ObfuscatedErrorText(w, err) {
 		return
 	}
-	payloadInfo, err := validationHandler.ValidatePayload(payloadBytes)
+	payloadInfo, err := validationHandler.ValidatePayload(payloadBytes, a.RegionRx)
 	if err != nil {
 		http.Error(w, "invalid event payload: "+err.Error(), http.StatusUnprocessableEntity)
 		return

--- a/internal/api/events_test.go
+++ b/internal/api/events_test.go
@@ -21,6 +21,7 @@ func TestMain(m *testing.M) {
 }
 
 func TestPostNewEvent(t *testing.T) {
+	t.Setenv("TENSO_REGION_REGEX", "[a-z]{2}-[a-z]{2}-[0-9][a-z]")
 	s := test.NewSetup(t,
 		test.WithAPI,
 		test.WithRoute("test-foo.v1 -> test-bar.v1"),

--- a/internal/api/events_test.go
+++ b/internal/api/events_test.go
@@ -21,7 +21,7 @@ func TestMain(m *testing.M) {
 }
 
 func TestPostNewEvent(t *testing.T) {
-	t.Setenv("TENSO_REGION_REGEX", "[a-z]{2}-[a-z]{2}-[0-9][a-z]")
+	t.Setenv("TENSO_REGION_REGEX", "[a-z]{2}-[a-z]{2}-[0-9]")
 	s := test.NewSetup(t,
 		test.WithAPI,
 		test.WithRoute("test-foo.v1 -> test-bar.v1"),

--- a/internal/handlers/active-directory-deployment.go
+++ b/internal/handlers/active-directory-deployment.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"regexp"
 	"strings"
 	"time"
 
@@ -99,7 +100,7 @@ func (v *activeDirectoryDeploymentV1Validator) PluginTypeID() string {
 }
 
 // ValidatePayload implements the tenso.ValidationHandler interface.
-func (v *activeDirectoryDeploymentV1Validator) ValidatePayload(payload []byte) (*tenso.PayloadInfo, error) {
+func (v *activeDirectoryDeploymentV1Validator) ValidatePayload(payload []byte, regionRx *regexp.Regexp) (*tenso.PayloadInfo, error) {
 	event, err := jsonUnmarshalStrict[activeDirectoryDeploymentV1Event](payload)
 	if err != nil {
 		return nil, err
@@ -243,8 +244,8 @@ func (v *activeDirectoryDeploymentV2Validator) PluginTypeID() string {
 }
 
 // ValidatePayload implements the tenso.ValidationHandler interface.
-func (v *activeDirectoryDeploymentV2Validator) ValidatePayload(payload []byte) (*tenso.PayloadInfo, error) {
-	event, err := parseAndValidateDeployEvent(payload)
+func (v *activeDirectoryDeploymentV2Validator) ValidatePayload(payload []byte, regionRx *regexp.Regexp) (*tenso.PayloadInfo, error) {
+	event, err := parseAndValidateDeployEvent(payload, regionRx)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/handlers/active-directory-deployment_test.go
+++ b/internal/handlers/active-directory-deployment_test.go
@@ -6,6 +6,7 @@ package handlers_test
 import (
 	"fmt"
 	"os"
+	"regexp"
 	"testing"
 
 	"github.com/sapcc/go-bits/assert"
@@ -16,6 +17,7 @@ import (
 
 func TestActiveDirectoryDeploymentValidationSuccess(t *testing.T) {
 	t.Setenv("TENSO_SERVICENOW_MAPPING_CONFIG_PATH", "fixtures/servicenow-mapping-config.json")
+	regionRx := regexp.MustCompile("^[a-z]{2}-[a-z]{2}-[0-9]$")
 
 	for _, eventFormat := range []string{"v1", "v2"} {
 		t.Logf("-- testing event format %s", eventFormat)
@@ -35,7 +37,7 @@ func TestActiveDirectoryDeploymentValidationSuccess(t *testing.T) {
 
 		for _, tc := range testCases {
 			sourcePayloadBytes := must.ReturnT(os.ReadFile(tc))(t)
-			payloadInfo := must.ReturnT(vh.ValidatePayload(sourcePayloadBytes))(t)
+			payloadInfo := must.ReturnT(vh.ValidatePayload(sourcePayloadBytes, regionRx))(t)
 			assert.Equal(t, payloadInfo.Description, "core/active-directory: deploy AD to ad-dev.example.sap")
 		}
 	}

--- a/internal/handlers/awx-workflow.go
+++ b/internal/handlers/awx-workflow.go
@@ -17,6 +17,7 @@ import (
 	"github.com/gophercloud/gophercloud/v2/openstack"
 	"github.com/sapcc/go-api-declarations/deployevent"
 	"github.com/sapcc/go-bits/osext"
+	"github.com/sapcc/go-bits/regexpext"
 	"go.xyrillian.de/schwift/v2"
 	"go.xyrillian.de/schwift/v2/gopherschwift"
 
@@ -97,10 +98,20 @@ func (t *awxWorkflowTime) UnmarshalJSON(buf []byte) error {
 // ValidationHandler
 
 type awxWorkflowValidator struct {
+	azRx *regexp.Regexp
 }
 
 // Init implements the tenso.ValidationHandler interface.
 func (a *awxWorkflowValidator) Init(context.Context, *gophercloud.ProviderClient, gophercloud.EndpointOpts) error {
+	azRxEnvVar := "TENSO_AWX_WORKFLOW_AZ_REGEX"
+	azRxString, err := osext.NeedGetenv(azRxEnvVar)
+	if err != nil {
+		return err
+	}
+	a.azRx, err = regexpext.BoundedRegexp(azRxString).Regexp()
+	if err != nil {
+		return fmt.Errorf("while compiling %s: %w", azRxEnvVar, err)
+	}
 	return nil
 }
 
@@ -109,12 +120,8 @@ func (a *awxWorkflowValidator) PluginTypeID() string {
 	return "infra-workflow-from-awx.v1"
 }
 
-var (
-	availabilityZoneRx = regexp.MustCompile(`^[a-z]{2}-[a-z]{2}-[0-9][a-z]$`) // e.g. "qa-de-1a"
-)
-
 // ValidatePayload implements the tenso.ValidationHandler interface.
-func (a *awxWorkflowValidator) ValidatePayload(payload []byte) (*tenso.PayloadInfo, error) {
+func (a *awxWorkflowValidator) ValidatePayload(payload []byte, _ *regexp.Regexp) (*tenso.PayloadInfo, error) {
 	event, err := jsonUnmarshalStrict[awxWorkflowEvent](payload)
 	if err != nil {
 		return nil, err
@@ -135,7 +142,7 @@ func (a *awxWorkflowValidator) ValidatePayload(payload []byte) (*tenso.PayloadIn
 	if _, ok := awxOutcomes[event.Status]; !ok {
 		return nil, fmt.Errorf(`invalid value for field "status": %q`, event.Status)
 	}
-	if !availabilityZoneRx.MatchString(event.AvailabilityZone) {
+	if !a.azRx.MatchString(event.AvailabilityZone) {
 		return nil, fmt.Errorf(`invalid value for field "inventory": %q is not an AZ name`, event.AvailabilityZone)
 	}
 

--- a/internal/handlers/awx-workflow_test.go
+++ b/internal/handlers/awx-workflow_test.go
@@ -5,6 +5,7 @@ package handlers_test
 
 import (
 	"os"
+	"regexp"
 	"testing"
 
 	"github.com/sapcc/go-bits/assert"
@@ -15,6 +16,8 @@ import (
 
 func TestAWXWorkflowValidationAndConversionToSNow(t *testing.T) {
 	t.Setenv("TENSO_SERVICENOW_MAPPING_CONFIG_PATH", "fixtures/servicenow-mapping-config.json")
+	t.Setenv("TENSO_AWX_WORKFLOW_AZ_REGEX", "[a-z]{2}-[a-z]{2}-[0-9][a-z]")
+	regionRx := regexp.MustCompile("^[a-z]{2}-[a-z]{2}-[0-9]$")
 
 	s := test.NewSetup(t,
 		test.WithRoute("infra-workflow-from-awx.v1 -> infra-workflow-to-servicenow.v1"),
@@ -23,7 +26,7 @@ func TestAWXWorkflowValidationAndConversionToSNow(t *testing.T) {
 	th := s.Config.EnabledRoutes[0].TranslationHandler
 
 	sourcePayloadBytes := must.ReturnT(os.ReadFile("fixtures/infra-workflow-from-awx.v1.good.json"))(t)
-	payloadInfo := must.ReturnT(vh.ValidatePayload(sourcePayloadBytes))(t)
+	payloadInfo := must.ReturnT(vh.ValidatePayload(sourcePayloadBytes, regionRx))(t)
 	assert.Equal(t, payloadInfo.Description, "ESX upgrade, qa-de-1a, node002-bb091.cc.qa-de-1.cloud.sap")
 
 	targetPayloadBytes := must.ReturnT(th.TranslatePayload(sourcePayloadBytes, nil))(t)

--- a/internal/handlers/helm-deployment.go
+++ b/internal/handlers/helm-deployment.go
@@ -49,14 +49,14 @@ type helmDeploymentValidator struct {
 
 // Init implements the tenso.ValidationHandler interface.
 func (h *helmDeploymentValidator) Init(context.Context, *gophercloud.ProviderClient, gophercloud.EndpointOpts) error {
-	clusterRegexEnvVar := "TENSO_HELM_DEPLOYMENT_CLUSTER_REGEX"
-	clusterString, err := osext.NeedGetenv(clusterRegexEnvVar)
+	clusterRxEnvVar := "TENSO_HELM_DEPLOYMENT_CLUSTER_REGEX"
+	clusterRxString, err := osext.NeedGetenv(clusterRxEnvVar)
 	if err != nil {
 		return err
 	}
-	h.clusterRx, err = regexpext.BoundedRegexp(clusterString).Regexp()
+	h.clusterRx, err = regexpext.BoundedRegexp(clusterRxString).Regexp()
 	if err != nil {
-		return fmt.Errorf("while compiling %s: %w", clusterRegexEnvVar, err)
+		return fmt.Errorf("while compiling %s: %w", clusterRxEnvVar, err)
 	}
 	return nil
 }
@@ -67,8 +67,8 @@ func (h *helmDeploymentValidator) PluginTypeID() string {
 }
 
 // ValidatePayload implements the tenso.ValidationHandler interface.
-func (h *helmDeploymentValidator) ValidatePayload(payload []byte) (*tenso.PayloadInfo, error) {
-	event, err := parseAndValidateDeployEvent(payload)
+func (h *helmDeploymentValidator) ValidatePayload(payload []byte, regionRx *regexp.Regexp) (*tenso.PayloadInfo, error) {
+	event, err := parseAndValidateDeployEvent(payload, regionRx)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/handlers/helm-deployment_test.go
+++ b/internal/handlers/helm-deployment_test.go
@@ -6,6 +6,7 @@ package handlers_test
 import (
 	"fmt"
 	"os"
+	"regexp"
 	"testing"
 
 	"github.com/sapcc/go-bits/assert"
@@ -19,6 +20,7 @@ func TestHelmDeploymentValidationSuccess(t *testing.T) {
 	// we will not be using this, but we need some config for the DeliveryHandler for the test.Setup() to go through
 	t.Setenv("TENSO_HELM_DEPLOYMENT_LOGSTASH_HOST", "localhost:1")
 	t.Setenv("TENSO_HELM_DEPLOYMENT_CLUSTER_REGEX", "[a-z]{2}-[a-z]{2}-[0-9]{1}")
+	regionRx := regexp.MustCompile("^[a-z]{2}-[a-z]{2}-[0-9]$")
 
 	s := test.NewSetup(t,
 		test.WithRoute("helm-deployment-from-concourse.v1 -> helm-deployment-to-elk.v1"),
@@ -41,7 +43,7 @@ func TestHelmDeploymentValidationSuccess(t *testing.T) {
 
 	for _, tc := range testCases {
 		sourcePayloadBytes := must.ReturnT(os.ReadFile(fmt.Sprintf("fixtures/helm-deployment-from-concourse.v1.%s.json", tc.ReleaseName)))(t)
-		payloadInfo := must.ReturnT(vh.ValidatePayload(sourcePayloadBytes))(t)
+		payloadInfo := must.ReturnT(vh.ValidatePayload(sourcePayloadBytes, regionRx))(t)
 		assert.Equal(t, payloadInfo.Description, tc.ExpectedDescription)
 	}
 }

--- a/internal/handlers/terraform-deployment.go
+++ b/internal/handlers/terraform-deployment.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"regexp"
 	"sort"
 	"strings"
 	"time"
@@ -45,8 +46,8 @@ func (v *terraformDeploymentValidator) PluginTypeID() string {
 }
 
 // ValidatePayload implements the tenso.ValidationHandler interface.
-func (v *terraformDeploymentValidator) ValidatePayload(payload []byte) (*tenso.PayloadInfo, error) {
-	event, err := parseAndValidateDeployEvent(payload)
+func (v *terraformDeploymentValidator) ValidatePayload(payload []byte, regionRx *regexp.Regexp) (*tenso.PayloadInfo, error) {
+	event, err := parseAndValidateDeployEvent(payload, regionRx)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/handlers/terraform-deployment_test.go
+++ b/internal/handlers/terraform-deployment_test.go
@@ -5,6 +5,7 @@ package handlers_test
 
 import (
 	"os"
+	"regexp"
 	"testing"
 
 	"github.com/sapcc/go-bits/assert"
@@ -15,6 +16,7 @@ import (
 
 func TestTerraformDeploymentValidationSuccess(t *testing.T) {
 	t.Setenv("TENSO_SERVICENOW_MAPPING_CONFIG_PATH", "fixtures/servicenow-mapping-config.json")
+	regionRx := regexp.MustCompile("^[a-z]{2}-[a-z]{2}-[0-9]$")
 
 	s := test.NewSetup(t,
 		test.WithRoute("terraform-deployment-from-concourse.v1 -> terraform-deployment-to-servicenow.v1"),
@@ -22,7 +24,7 @@ func TestTerraformDeploymentValidationSuccess(t *testing.T) {
 	vh := s.Config.EnabledRoutes[0].ValidationHandler
 
 	sourcePayloadBytes := must.ReturnT(os.ReadFile("fixtures/terraform-deployment-from-concourse.v1.terragrunt-virtual-apod.json"))(t)
-	payloadInfo := must.ReturnT(vh.ValidatePayload(sourcePayloadBytes))(t)
+	payloadInfo := must.ReturnT(vh.ValidatePayload(sourcePayloadBytes, regionRx))(t)
 	assert.Equal(t, payloadInfo.Description, "services/terragrunt-virtual-apod: Terraform run for vnode4-v-qa-de-1")
 }
 

--- a/internal/handlers/utils.go
+++ b/internal/handlers/utils.go
@@ -30,7 +30,6 @@ func jsonUnmarshalStrict[T any](payload []byte) (T, error) {
 // terraform-deployment)
 
 var (
-	regionRx      = regexp.MustCompile(`^[a-z]{2}-[a-z]{2}-[0-9]$`)       // e.g. "qa-de-1"
 	gitCommitRx   = regexp.MustCompile(`^[0-9a-f]{40}$`)                  // SHA-1 digest with lower-case digits
 	buildNumberRx = regexp.MustCompile(`^[1-9][0-9]*(?:\.[1-9][0-9]*)?$`) // e.g. "23" or "42.1"
 	sapUserIDRx   = regexp.MustCompile(`^(?:C[0-9]{7}|[DI][0-9]{6})$`)    // e.g. "D123456" or "C1234567"
@@ -41,7 +40,7 @@ func isClusterLocatedInRegion(cluster, region string) bool {
 		return region == "eu-nl-1"
 	}
 	if strings.HasSuffix(cluster, "-ora-1") {
-		return region == "eu-de-1"
+		return region == "ora"
 	}
 	qaClusters := map[string]struct{}{
 		"a-qa-de-100": {},
@@ -57,7 +56,7 @@ func isClusterLocatedInRegion(cluster, region string) bool {
 	return strings.HasSuffix(cluster, region)
 }
 
-func parseAndValidateDeployEvent(payload []byte) (deployevent.Event, error) {
+func parseAndValidateDeployEvent(payload []byte, regionRx *regexp.Regexp) (deployevent.Event, error) {
 	event, err := jsonUnmarshalStrict[deployevent.Event](payload)
 	if err != nil {
 		return deployevent.Event{}, err

--- a/internal/tenso/handlers.go
+++ b/internal/tenso/handlers.go
@@ -6,6 +6,7 @@ package tenso
 import (
 	"context"
 	"fmt"
+	"regexp"
 	"strings"
 
 	"github.com/gophercloud/gophercloud/v2"
@@ -23,7 +24,7 @@ type ValidationHandler interface {
 	// talk to OpenStack. During unit tests, (nil, nil) will be provided instead.
 	Init(ctx context.Context, pc *gophercloud.ProviderClient, eo gophercloud.EndpointOpts) error
 
-	ValidatePayload(payload []byte) (*PayloadInfo, error)
+	ValidatePayload(payload []byte, regionRx *regexp.Regexp) (*PayloadInfo, error)
 }
 
 // PayloadInfo contains structured information about a payload. It is returned

--- a/internal/test/handlers.go
+++ b/internal/test/handlers.go
@@ -9,6 +9,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"regexp"
 
 	"github.com/gophercloud/gophercloud/v2"
 
@@ -63,7 +64,7 @@ func (h *testValidationHandler) PluginTypeID() string {
 }
 
 // ValidatePayload implements the tenso.ValidationHandler interface.
-func (h *testValidationHandler) ValidatePayload(data []byte) (*tenso.PayloadInfo, error) {
+func (h *testValidationHandler) ValidatePayload(data []byte, _ *regexp.Regexp) (*tenso.PayloadInfo, error) {
 	p, err := parseTestPayload(data, h.Type)
 	if err != nil {
 		return nil, err

--- a/internal/test/setup.go
+++ b/internal/test/setup.go
@@ -60,6 +60,7 @@ type Setup struct {
 	// fields that are set if WithAPI is included
 	Validator *mock.Validator[*mock.Enforcer]
 	Handler   httptest.Handler
+	API       *api.API
 	// fields that are set if WithTaskContext is included
 	TaskContext *tasks.Context
 }
@@ -97,8 +98,9 @@ func NewSetup(t *testing.T, opts ...SetupOption) Setup {
 			"user_id":          "testuserid",
 			"user_domain_name": "testdomainname",
 		})
+		s.API = must.ReturnT(api.NewAPI(s.Config, s.DB, s.Validator))(t).OverrideTimeNow(s.Clock.Now)
 		s.Handler = httptest.NewHandler(httpapi.Compose(
-			api.NewAPI(s.Config, s.DB, s.Validator).OverrideTimeNow(s.Clock.Now),
+			s.API,
 			httpapi.WithoutLogging(),
 		))
 	}

--- a/main.go
+++ b/main.go
@@ -93,7 +93,7 @@ func runAPI(ctx context.Context, cfg tenso.Configuration, db *gorp.DbMap, provid
 		AllowedHeaders: []string{"Content-Type", "User-Agent", "X-Auth-Token", "Authorization"},
 	})
 	handler := httpapi.Compose(
-		api.NewAPI(cfg, db, &tv),
+		must.Return(api.NewAPI(cfg, db, &tv)),
 		httpapi.HealthCheckAPI{
 			SkipRequestLog: true,
 			Check: func() error {


### PR DESCRIPTION
I should have anticipated it...
If it was just one more value to set, I would have switched to a config json instead, but I liked the env vars more for setting up the tests as is.

Please don't forget the helm-chart PR: https://github.com/sapcc/helm-charts/pull/11593